### PR TITLE
add(rpc-extractor, metrics): estimatesmartfee metric

### DIFF
--- a/extractors/rpc/README.md
+++ b/extractors/rpc/README.md
@@ -69,6 +69,8 @@ Options:
           Disable querying and publishing of `getorphantxs` data
       --disable-getrawaddrman
           Disable querying and publishing of `getrawaddrman` data
+      --disable-getestimatesmartfee
+          Disable querying and publishing of `estimatesmartfee` data
   -h, --help
           Print help
   -V, --version

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -1,6 +1,7 @@
 use shared::clap::{ArgGroup, Parser};
 use shared::corepc_client::client_sync::Auth;
 use shared::corepc_client::client_sync::v30::Client;
+use shared::corepc_client::types::v30::EstimateSmartFee as RPCEstimateSmartFee;
 use shared::corepc_node::mtype::{
     GetBlockchainInfo, GetChainTxStats, GetNetworkInfo, GetOrphanTxsVerboseTwo,
 };
@@ -9,7 +10,7 @@ use shared::nats_subjects::Subject;
 use shared::nats_util::{self, NatsArgs};
 use shared::prost::Message;
 use shared::protobuf::event::{Event, event::PeerObserverEvent};
-use shared::protobuf::rpc_extractor;
+use shared::protobuf::rpc_extractor::{self, EstimateSmartFee, FeeEstimateMode};
 use shared::tokio::sync::watch;
 use shared::tokio::time::{self, Duration};
 use shared::{async_nats, clap};
@@ -116,6 +117,10 @@ pub struct Args {
     /// Disable querying and publishing of `getrawaddrman` data.
     #[arg(long, default_value_t = false)]
     pub disable_getrawaddrman: bool,
+
+    /// Disable querying and publishing of `estimatesmartfee` data.
+    #[arg(long, default_value_t = false)]
+    pub disable_getestimatesmartfee: bool,
 }
 
 impl Args {
@@ -139,6 +144,7 @@ impl Args {
         disable_getblockchaininfo: bool,
         disable_getorphantxs: bool,
         disable_getrawaddrman: bool,
+        disable_getestimatesmartfee: bool,
     ) -> Args {
         Self {
             nats,
@@ -161,6 +167,7 @@ impl Args {
             disable_getblockchaininfo,
             disable_getorphantxs,
             disable_getrawaddrman,
+            disable_getestimatesmartfee,
             // when adding more disable_* args, make sure to update the disable_all below
         }
     }
@@ -243,6 +250,10 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         "Querying getrawaddrman enabled: {}",
         !args.disable_getrawaddrman
     );
+    log::info!(
+        "Querying estimatesmartfee enabled: {}",
+        !args.disable_getestimatesmartfee
+    );
     // check if we have at least one RPC to query
     let disable_all = args.disable_getpeerinfo
         && args.disable_getmempoolinfo
@@ -254,7 +265,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         && args.disable_getnetworkinfo
         && args.disable_getblockchaininfo
         && args.disable_getorphantxs
-        && args.disable_getrawaddrman;
+        && args.disable_getrawaddrman
+        && args.disable_getestimatesmartfee;
     if disable_all {
         log::warn!("No RPC configured to be queried!");
     }
@@ -293,6 +305,10 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                 if !args.disable_getorphantxs
                     && let Err(e) = getorphantxs(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getorphantxs': {}", e)
+                }
+                if !args.disable_getestimatesmartfee
+                    && let Err(e) = getestimatesmartfee(&rpc_client, &nats_client, &metrics).await {
+                        log::error!("Could not fetch and publish 'getestimatesmartfee': {}", e)
                 }
             }
             _ = less_frequent_interval.tick() => {
@@ -629,5 +645,63 @@ async fn getrawaddrman(
                 .with_label_values(&["getrawaddrman"])
                 .inc();
         })?;
+    Ok(())
+}
+
+async fn getestimatesmartfee(
+    rpc_client: &Client,
+    nats_client: &async_nats::Client,
+    metrics: &Metrics,
+) -> Result<(), FetchOrPublishError> {
+    const BLOCKS_10MIN: u32 = 1;
+    const BLOCKS_1HOUR: u32 = 6;
+    const BLOCKS_1DAY: u32 = 144;
+    const BLOCK_TARGETS: [u32; 3] = [BLOCKS_10MIN, BLOCKS_1HOUR, BLOCKS_1DAY];
+
+    const MODES: [FeeEstimateMode; 2] =
+        [FeeEstimateMode::Economical, FeeEstimateMode::Conservative];
+
+    for target in BLOCK_TARGETS {
+        for mode in MODES {
+            let estimative: RPCEstimateSmartFee =
+                measure_rpc_call("estimatesmartfee", metrics, || {
+                    // TODO: when https://github.com/rust-bitcoin/corepc/pull/531 gets released
+                    // use estimate_smart_fee_with_mode instead of the generic call
+                    rpc_client.call::<RPCEstimateSmartFee>(
+                        "estimatesmartfee",
+                        &[target.into(), mode.to_string().into()],
+                    )
+                })?;
+            if estimative.errors.is_some() {
+                log::warn!(
+                    "Received error(s) in estimatesmartfee RPC response for target {} and mode {:?}: {:?}",
+                    target,
+                    mode,
+                    estimative.errors
+                );
+                continue;
+            }
+
+            let mut estimative: EstimateSmartFee = estimative.into();
+            estimative.blocks = target; // TODO: core outputs a different value from what we send, should we override?
+            estimative.mode = mode.into();
+
+            let estimative = rpc_extractor::rpc::RpcEvent::EstimateSmartFee(estimative);
+            let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+                rpc_event: Some(estimative),
+            }))?;
+
+            nats_client
+                .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
+                .await
+                .inspect_err(|_| {
+                    metrics
+                        .nats_publish_errors
+                        .with_label_values(&["estimatesmartfee"])
+                        .inc();
+                })?;
+        }
+    }
+
     Ok(())
 }

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -46,6 +46,7 @@ pub struct EnabledRPCsInTest {
     pub getblockchaininfo: bool,
     pub getorphantxs: bool,
     pub getrawaddrman: bool,
+    pub estimatesmartfee: bool,
 }
 
 #[allow(dead_code)]
@@ -64,6 +65,7 @@ impl EnabledRPCsInTest {
             getblockchaininfo: true,
             getorphantxs: true,
             getrawaddrman: true,
+            estimatesmartfee: true,
         }
     }
 
@@ -104,6 +106,9 @@ impl EnabledRPCsInTest {
         if self.getrawaddrman {
             methods.push("getrawaddrman");
         }
+        if self.estimatesmartfee {
+            methods.push("estimatesmartfee");
+        }
         methods
     }
 }
@@ -139,6 +144,7 @@ pub fn make_test_args(
         !rpcs.getblockchaininfo,
         !rpcs.getorphantxs,
         !rpcs.getrawaddrman,
+        !rpcs.estimatesmartfee,
     )
 }
 

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -18,9 +18,12 @@ use shared::{
     prost::Message,
     protobuf::{
         event::{Event, event::PeerObserverEvent},
-        rpc_extractor::rpc::RpcEvent::{
-            Addrman, AddrmanInfo, BlockchainInfo, ChainTxStats, MemoryInfo, MempoolInfo, NetTotals,
-            NetworkInfo, OrphanTxs, PeerInfos, Uptime,
+        rpc_extractor::{
+            FeeEstimateMode,
+            rpc::RpcEvent::{
+                Addrman, AddrmanInfo, BlockchainInfo, ChainTxStats, EstimateSmartFee, MemoryInfo,
+                MempoolInfo, NetTotals, NetworkInfo, OrphanTxs, PeerInfos, Uptime,
+            },
         },
     },
     testing::nats_server::NatsServerForTesting,
@@ -39,7 +42,7 @@ const TEST_TIMEOUT_SECONDS: u64 = 5;
 async fn check(
     rpcs: EnabledRPCsInTest,
     test_setup: fn(&corepc_node::Node, &corepc_node::Node),
-    check_expected: fn(PeerObserverEvent) -> (),
+    mut check_expected: impl FnMut(PeerObserverEvent),
 ) {
     setup();
     let (node1, node2) = setup_two_connected_nodes();
@@ -585,6 +588,74 @@ async fn test_integration_rpc_testsshouldtimeout() {
         |event| match event {
             PeerObserverEvent::RpcExtractor(_) => {
                 panic!("We should never receive an event here.")
+            }
+            _ => panic!("unexpected event {:?}", event),
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_rpc_estimatesmartfee() {
+    println!("test that we receive estimatesmartfee RPC events");
+
+    let expected_combinations = [
+        (1, FeeEstimateMode::Economical as i32),
+        (1, FeeEstimateMode::Conservative as i32),
+        (6, FeeEstimateMode::Economical as i32),
+        (6, FeeEstimateMode::Conservative as i32),
+        (144, FeeEstimateMode::Economical as i32),
+        (144, FeeEstimateMode::Conservative as i32),
+    ];
+
+    check(
+        EnabledRPCsInTest {
+            estimatesmartfee: true,
+            ..Default::default()
+        },
+        |node1, node2| {
+            let miner_address = node1
+                .client
+                .new_address()
+                .expect("failed to get new address");
+            node1
+                .client
+                .generate_to_address(101, &miner_address)
+                .expect("failed to generate to address");
+
+            for _ in 0..20 {
+                let address = node2
+                    .client
+                    .new_address()
+                    .expect("failed to get new address");
+                node1
+                    .client
+                    .call::<String>("sendtoaddress", &[address.to_string().into(), "1".into()])
+                    .expect("failed to send to address");
+
+                node1
+                    .client
+                    .generate_to_address(1, &miner_address)
+                    .expect("failed to generate to address");
+            }
+        },
+        |event| match event {
+            PeerObserverEvent::RpcExtractor(r) => {
+                if let Some(ref e) = r.rpc_event {
+                    match e {
+                        EstimateSmartFee(result) => {
+                            // Fee rate most of the time is 0.0001_0000 on this scenario, but sometimes is greater
+                            assert!(result.fee_rate >= 10.0);
+
+                            let found = expected_combinations.iter().any(|(blocks, mode)| {
+                                *blocks == result.blocks && *mode == result.mode
+                            });
+
+                            assert!(found);
+                        }
+                        _ => panic!("unexpected RPC data {:?}", r.rpc_event),
+                    }
+                }
             }
             _ => panic!("unexpected event {:?}", event),
         },

--- a/protobuf/rpc_extractor.proto
+++ b/protobuf/rpc_extractor.proto
@@ -17,6 +17,7 @@ message rpc {
     BlockchainInfo blockchain_info = 9;
     OrphanTxs orphan_txs = 10;
     Addrman addrman = 11;
+    EstimateSmartFee estimate_smart_fee = 12;
   }
 }
 
@@ -239,4 +240,16 @@ message AddrmanEntry {
   required string source_network        = 7;    // The network (ipv4, ipv6, onion, i2p, cjdns) of the source address
   optional uint32 mapped_as             = 8;    // Mapped AS (Autonomous System) number at the end of the BGP route to the peer, used for diversifying peer selection (only displayed if the -asmap config option is set)
   optional uint32 source_mapped_as      = 9;    // Mapped AS (Autonomous System) number at the end of the BGP route to the source, used for diversifying peer selection (only displayed if the -asmap config option is set)
+}
+
+enum FeeEstimateMode {
+  UNSET = 0;
+  ECONOMICAL = 1;
+  CONSERVATIVE = 2;
+}
+
+message EstimateSmartFee {
+  required double fee_rate = 1; // The estimated fee rate in sat/vB
+  required uint32 blocks = 2; // The target number of blocks for confirmation
+  required FeeEstimateMode mode = 3;
 }

--- a/shared/src/protobuf/rpc_extractor.rs
+++ b/shared/src/protobuf/rpc_extractor.rs
@@ -4,10 +4,10 @@ use bitcoin::FeeRate;
 // Once they have a model, move them down to the mtypes!
 // CORE_VERSION_GREP: When updating the corepc node crate version, bump this too.
 use corepc_client::types::v30::{
-    AddrManInfoNetwork as RPCAddrManInfoNetwork, GetAddrManInfo as RPCGetAddrManInfo,
-    GetMemoryInfoStats as RPCGetMemoryInfoStats, GetNetTotals as RPCGetNetTotals,
-    GetPeerInfo as RPCGetPeerInfo, GetRawAddrMan, PeerInfo as RPCPeerInfo, RawAddrManEntry,
-    UploadTarget as RPCUploadTarget,
+    AddrManInfoNetwork as RPCAddrManInfoNetwork, EstimateSmartFee as RPCEstimateSmartFee,
+    GetAddrManInfo as RPCGetAddrManInfo, GetMemoryInfoStats as RPCGetMemoryInfoStats,
+    GetNetTotals as RPCGetNetTotals, GetPeerInfo as RPCGetPeerInfo, GetRawAddrMan,
+    PeerInfo as RPCPeerInfo, RawAddrManEntry, UploadTarget as RPCUploadTarget,
 };
 
 // Ideally, all type imports should use the generic mtype types.
@@ -68,6 +68,7 @@ impl fmt::Display for rpc::RpcEvent {
             rpc::RpcEvent::BlockchainInfo(info) => write!(f, "{}", info),
             rpc::RpcEvent::OrphanTxs(orphans) => write!(f, "{}", orphans),
             rpc::RpcEvent::Addrman(addrman) => write!(f, "{}", addrman),
+            rpc::RpcEvent::EstimateSmartFee(fee) => write!(f, "{}", fee),
         }
     }
 }
@@ -534,6 +535,38 @@ impl From<GetRawAddrMan> for Addrman {
         Addrman {
             new: table_to_addrman_buckets(&addrman.new),
             tried: table_to_addrman_buckets(&addrman.tried),
+        }
+    }
+}
+
+impl fmt::Display for EstimateSmartFee {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mode = FeeEstimateMode::try_from(self.mode)
+            .expect("Estimate mode must be a valid FeeEstimateMode enum variant");
+
+        write!(
+            f,
+            "EstimateSmartFee(fee_rate={}sat/vB, blocks={}, mode={})",
+            self.fee_rate, self.blocks, mode,
+        )
+    }
+}
+
+impl fmt::Display for FeeEstimateMode {
+    fn fmt(&self, estimate: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(estimate, "{}", self.as_str_name())
+    }
+}
+
+impl From<RPCEstimateSmartFee> for EstimateSmartFee {
+    fn from(estimate: RPCEstimateSmartFee) -> Self {
+        let fee_rate_btc_per_kvb = estimate.fee_rate.unwrap_or(0.);
+        let fee_rate_sat_per_vb = fee_rate_btc_per_kvb * 1e8 / 1e3;
+
+        EstimateSmartFee {
+            fee_rate: fee_rate_sat_per_vb,
+            blocks: estimate.blocks,
+            mode: FeeEstimateMode::default().into(),
         }
     }
 }

--- a/tools/metrics/dashboards/fees-estimatesmartfee.json
+++ b/tools/metrics/dashboards/fees-estimatesmartfee.json
@@ -1,0 +1,279 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "fffy1o0fm85j4a"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fffy1o0fm85j4a"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"1\", mode=\"CONSERVATIVE\"}",
+          "legendFormat": "{{target_block}} blocks",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fffy1o0fm85j4a"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"6\", mode=\"CONSERVATIVE\"}",
+          "legendFormat": "{{target_block}} blocks",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fffy1o0fm85j4a"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"144\", mode=\"CONSERVATIVE\"}",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{target_block}} blocks",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Fee Rate Estimate – Conservative (sat/vB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "fffy1o0fm85j4a"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fffy1o0fm85j4a"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"1\", mode=\"ECONOMICAL\"}",
+          "legendFormat": "{{target_block}} blocks",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fffy1o0fm85j4a"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"6\", mode=\"ECONOMICAL\"}",
+          "legendFormat": "{{target_block}} blocks",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fffy1o0fm85j4a"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"144\", mode=\"ECONOMICAL\"}",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{target_block}} blocks",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Fee Rate Estimate – Economical (sat/vB)",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "[fees] Fee Rate Estimates",
+  "uid": "ad72ms8",
+  "version": 18,
+  "weekStart": ""
+}

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -22,7 +22,7 @@ use shared::protobuf::{
     event::{event::PeerObserverEvent, Event},
     log_extractor::{log, Log, LogDebugCategory},
     p2p_extractor::p2p,
-    rpc_extractor::{rpc, Addrman, AddrmanBucket},
+    rpc_extractor::{rpc, Addrman, AddrmanBucket, FeeEstimateMode},
 };
 use shared::tokio::sync::watch;
 use shared::util::{self, is_on_linkinglion_banlist};
@@ -980,6 +980,16 @@ fn handle_rpc_event(e: &rpc::RpcEvent, state_arc: Arc<Mutex<State>>, metrics: me
                     .inc_by(tried_changes.changed_timestamp);
             }
             state.addrman = addrman.clone();
+        }
+        rpc::RpcEvent::EstimateSmartFee(estimate) => {
+            let mode = FeeEstimateMode::try_from(estimate.mode)
+                .expect("Invalid fee estimate mode")
+                .to_string();
+
+            metrics
+                .rpc_estimatesmartfee_feerate
+                .with_label_values(&[&estimate.blocks.to_string(), &mode])
+                .set(estimate.fee_rate);
         }
     }
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -1,10 +1,12 @@
 use shared::prometheus::{
-    register_gauge_with_registry, register_histogram_vec_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, HistogramOpts, Opts,
-    Registry,
+    register_gauge_vec_with_registry, register_gauge_with_registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry, HistogramOpts, Opts, Registry,
 };
-use shared::prometheus::{Gauge, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+use shared::prometheus::{
+    Gauge, GaugeVec, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+};
 
 const NAMESPACE: &str = "peerobserver";
 
@@ -107,6 +109,16 @@ macro_rules! g {
         let $name: Gauge =
             register_gauge_with_registry!(Opts::new(stringify!($name), $desc), $registry)
                 .expect(concat!("Could not create metric '", stringify!($name), "'"));
+    };
+}
+macro_rules! gv {
+    ($name:ident, $desc:expr, $labels:expr, $registry:expr) => {
+        let $name: GaugeVec = register_gauge_vec_with_registry!(
+            Opts::new(stringify!($name), $desc),
+            &$labels,
+            $registry
+        )
+        .expect(concat!("Could not create metric '", stringify!($name), "'"));
     };
 }
 
@@ -353,6 +365,9 @@ pub struct Metrics {
     pub rpc_getrawaddrman_changed_services: IntCounterVec,
     pub rpc_getrawaddrman_changed_timestamps: IntCounterVec,
 
+    // estimatesmartfee
+    pub rpc_estimatesmartfee_feerate: GaugeVec,
+
     // P2P-extractor
     pub p2pextractor_ping_duration_nanoseconds: IntGauge,
     pub p2pextractor_addrv2relay_addresses: IntCounterVec,
@@ -566,6 +581,9 @@ impl Metrics {
         icv!(rpc_getrawaddrman_changed_services, "Number of entries where the services changed since the last fetch to the addrman by table.", ["table"], registry);
         icv!(rpc_getrawaddrman_changed_timestamps, "Number of entries where the timestamp changed since the last fetch to the addrman by table.", ["table"], registry);
 
+        // estimatesmartfee
+        gv!(rpc_estimatesmartfee_feerate, "The feerate estimate in sat/vB by target block and mode.", ["target_block", "mode"], registry);
+
         // P2P-extractor
         ig!(p2pextractor_ping_duration_nanoseconds, "The time it takes for a connected Bitcoin node to respond to a ping with a pong in nanoseconds.", registry);
         icv!(p2pextractor_addrv2relay_addresses, "The total number of addresses relayed to the p2p-extractor by the node, per network", ["network"], registry);
@@ -775,6 +793,9 @@ impl Metrics {
             rpc_getrawaddrman_replaced_entry,
             rpc_getrawaddrman_changed_timestamps,
             rpc_getrawaddrman_changed_services,
+
+            // estimatesmartfee
+            rpc_estimatesmartfee_feerate,
 
             // p2p-extractor
             p2pextractor_ping_duration_nanoseconds,

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -30,8 +30,9 @@ use shared::{
         p2p_extractor,
         rpc_extractor::{
             self, AddrManInfo, AddrManInfoNetwork, Addrman, AddrmanBucket, AddrmanEntry,
-            BlockchainInfo, ChainTxStats, MemoryInfo, MempoolInfo, NetTotals, NetworkInfo,
-            NetworkInfoNetwork, OrphanTx, OrphanTxs, PeerInfo, PeerInfos, UploadTarget,
+            BlockchainInfo, ChainTxStats, EstimateSmartFee, FeeEstimateMode, MemoryInfo,
+            MempoolInfo, NetTotals, NetworkInfo, NetworkInfoNetwork, OrphanTx, OrphanTxs, PeerInfo,
+            PeerInfos, UploadTarget,
         },
     },
     rand::{self, Rng},
@@ -3712,6 +3713,42 @@ async fn test_integration_metrics_rpc_getorphantxs() {
             peerobserver_rpc_getorphantxs_from_min 1
             peerobserver_rpc_getorphantxs_from_max 2
             peerobserver_rpc_getorphantxs_from_mean 1.5
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_metrics_rpc_estimatesmartfee() {
+    println!("test that the estimatesmartfee metrics work");
+
+    publish_and_check(
+        &[
+            Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+                rpc_event: Some(rpc_extractor::rpc::RpcEvent::EstimateSmartFee(
+                    EstimateSmartFee {
+                        fee_rate: 1.08,
+                        blocks: 144,
+                        mode: FeeEstimateMode::Economical.into(),
+                    },
+                )),
+            }))
+            .unwrap(),
+            Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+                rpc_event: Some(rpc_extractor::rpc::RpcEvent::EstimateSmartFee(
+                    EstimateSmartFee {
+                        fee_rate: 0.777,
+                        blocks: 6,
+                        mode: FeeEstimateMode::Conservative.into(),
+                    },
+                )),
+            }))
+            .unwrap(),
+        ],
+        Subject::Rpc,
+        r#"
+            peerobserver_rpc_estimatesmartfee_feerate{mode="CONSERVATIVE",target_block="6"} 0.777
+            peerobserver_rpc_estimatesmartfee_feerate{mode="ECONOMICAL",target_block="144"} 1.08
         "#,
     )
     .await;


### PR DESCRIPTION
Add `estimatesmartfee` calls that watch how the feerate values move for the combinations of target (1, 6, 144) and mode (economical, conservative).

This PR touches `rpc-extractor` and `metrics` tool.

**PR to test CI**, later I will open a draft on the main repo.